### PR TITLE
refactor ffgamma

### DIFF
--- a/doclosure.sh
+++ b/doclosure.sh
@@ -12,8 +12,8 @@ do
   ./ffgamma.exe /export/d00/scratch/dav2105/ztrees/g.Pythia8_Photon_Hydjet_MB-HINPbPbWinter16DR-75X_mcRun2_HeavyIon_forest_v1.root pbpbmc 20 60 $1 $2 $3 $i $4 $5 $6 &
   ./ffgamma.exe /export/d00/scratch/dav2105/ztrees/g.Pythia8_Photon_Hydjet_MB-HINPbPbWinter16DR-75X_mcRun2_HeavyIon_forest_v1.root pbpbmc 60 100 $1 $2 $3 $i $4 $5 $6 &
   ./ffgamma.exe /export/d00/scratch/dav2105/ztrees/g.Pythia8_Photon_Hydjet_MB-HINPbPbWinter16DR-75X_mcRun2_HeavyIon_forest_v1.root pbpbmc 100 200 $1 $2 $3 $i $4 $5 $6 &
-wait
 done
+wait
 
 
 hadd -f closure_pbpb_${1}_${2}_${3}_gammaxi${6}.root pbpbmc_pbpbmc_*_*.root

--- a/ffgamma.C
+++ b/ffgamma.C
@@ -288,7 +288,7 @@ void ztree::ffgammajet(std::string outfname, int centmin, int centmax, float pho
 //! (1.2) List of histograms
   TH1D * hphoSigmaIEtaIEta_2012 = new TH1D(Form("hphoSigmaIEtaIEta_2012_%s_%s_%d_%d",tag.data(),s_alpha.data(),abs(centmin),abs(centmax)),Form(";jet p_{T};"),40,0,0.02);
   TH1D * hgenjetpt = new TH1D(Form("hgenjetpt_%s_%s_%d_%d",tag.data(),s_alpha.data(),abs(centmin),abs(centmax)),Form(";genjet p_{T};"),20,0,500);
-  TH1D * hgenjetpt_mix = new TH1D(Form("hgenjetpt_mix_%s_%s_%d_%d",tag.data(),s_alpha.data(),abs(centmin),abs(centmax)),Form(";genjet_mix p_{T};"),20,0,500);
+  // TH1D * hgenjetpt_mix = new TH1D(Form("hgenjetpt_mix_%s_%s_%d_%d",tag.data(),s_alpha.data(),abs(centmin),abs(centmax)),Form(";genjet_mix p_{T};"),20,0,500);
   TH1D * hjetpt = new TH1D(Form("hjetpt_%s_%s_%d_%d",tag.data(),s_alpha.data(),abs(centmin),abs(centmax)),Form(";jet p_{T};"),20,0,500);
   TH1D * hjetptjetmix = new TH1D(Form("hjetptjetmix_%s_%s_%d_%d",tag.data(),s_alpha.data(),abs(centmin),abs(centmax)),Form(";jet p_{T};"),20,0,500);
   TH1D * hjetptsideband = new TH1D(Form("hjetptsideband_%s_%s_%d_%d",tag.data(),s_alpha.data(),abs(centmin),abs(centmax)),Form(";jet p_{T};"),20,0,500);
@@ -301,10 +301,10 @@ void ztree::ffgammajet(std::string outfname, int centmin, int centmax, float pho
   TH1D * hgammaffxijetmixuesideband = new TH1D(Form("hgammaffxijetmixuesideband_%s_%s_%d_%d",tag.data(),s_alpha.data(),abs(centmin),abs(centmax)),Form(";#xi=ln(1/z);"),10,0,5); // sideband sub mix jet ff (2.1)
   TH1D * hgammaffxiuemix = new TH1D(Form("hgammaffxiuemix_%s_%s_%d_%d",tag.data(),s_alpha.data(),abs(centmin),abs(centmax)),Form(";#xi=ln(1/z);"),10,0,5); // sub mix jet ff (3.0)
   TH1D * hgammaffxiuemixsideband = new TH1D(Form("hgammaffxiuemixsideband_%s_%s_%d_%d",tag.data(),s_alpha.data(),abs(centmin),abs(centmax)),Form(";#xi=ln(1/z);"),10,0,5); // sideband sub mix jet ff (3.1)
-  TH1D * hgammaffxiuesiggen = new TH1D(Form("hgammaffxiuesiggen_%s_%s_%d_%d",tag.data(),s_alpha.data(),abs(centmin),abs(centmax)),Form(";#xi=ln(1/z);"),10,0,5); // Raw FF after cuts (1.0)
-  TH1D * hgammaffxiuemixgen = new TH1D(Form("hgammaffxiuemixgen_%s_%s_%d_%d",tag.data(),s_alpha.data(),abs(centmin),abs(centmax)),Form(";#xi=ln(1/z);"),10,0,5); // Raw FF after cuts (1.0)
-  TH1D * hnjetperevt = new TH1D(Form("hnjetperevt_%s_%s_%d_%d",tag.data(),s_alpha.data(),abs(centmin),abs(centmax)),Form(";nJets per event;"),20,0.5,20.5); // Raw FF after cuts (1.0)
-  TH1D * hnjetpermixevt = new TH1D(Form("hnjetpermixevt_%s_%s_%d_%d",tag.data(),s_alpha.data(),abs(centmin),abs(centmax)),Form(";nJets per mixed event;"),20,0.5,20.5); // Raw FF after cuts (1.0)
+  // TH1D * hgammaffxiuesiggen = new TH1D(Form("hgammaffxiuesiggen_%s_%s_%d_%d",tag.data(),s_alpha.data(),abs(centmin),abs(centmax)),Form(";#xi=ln(1/z);"),10,0,5); // Raw FF after cuts (1.0)
+  // TH1D * hgammaffxiuemixgen = new TH1D(Form("hgammaffxiuemixgen_%s_%s_%d_%d",tag.data(),s_alpha.data(),abs(centmin),abs(centmax)),Form(";#xi=ln(1/z);"),10,0,5); // Raw FF after cuts (1.0)
+  // TH1D * hnjetperevt = new TH1D(Form("hnjetperevt_%s_%s_%d_%d",tag.data(),s_alpha.data(),abs(centmin),abs(centmax)),Form(";nJets per event;"),20,0.5,20.5); // Raw FF after cuts (1.0)
+  // TH1D * hnjetpermixevt = new TH1D(Form("hnjetpermixevt_%s_%s_%d_%d",tag.data(),s_alpha.data(),abs(centmin),abs(centmax)),Form(";nJets per mixed event;"),20,0.5,20.5); // Raw FF after cuts (1.0)
   TH1D * hnmixsignal = new TH1D(Form("hnmixsignal_%s_%s_%d_%d",tag.data(),s_alpha.data(),abs(centmin),abs(centmax)),Form(";#xi=ln(1/z);"),1,0,2); // Raw FF after cuts (1.0)
   TH1D * hnmixsideband = new TH1D(Form("hnmixsideband_%s_%s_%d_%d",tag.data(),s_alpha.data(),abs(centmin),abs(centmax)),Form(";#xi=ln(1/z);"),1,0,2); // Raw FF after cuts (1.0)
   TH1D * xjgsignal = new TH1D(Form("xjgsignal_%s_%s_%d_%d",tag.data(),s_alpha.data(),abs(centmin),abs(centmax)),Form(";xjg;"),16,0,2); // xjg crosscheck
@@ -322,7 +322,7 @@ void ztree::ffgammajet(std::string outfname, int centmin, int centmax, float pho
   int nij, nij_mix, nip, nip_mix;
   Int_t * j_ev_mix;
   Int_t * p_ev_mix;
-  
+
   Float_t * j_pt;
   Float_t * p_pt;
   Float_t * p_pt_mix;
@@ -344,6 +344,7 @@ void ztree::ffgammajet(std::string outfname, int centmin, int centmax, float pho
     if (ientry < 0) break;
 
     nb = fChain->GetEntry(jentry);   nbytes += nb;
+    float_to_int(trkFromEv_mix,trkFromEv_mix_int,nTrk_mix);
 //! (2.1) Event selections
     if(!isPP)
     {
@@ -405,7 +406,7 @@ void ztree::ffgammajet(std::string outfname, int centmin, int centmax, float pho
       p_pt_mix = trkPt_mix;
       p_eta_mix = trkEta_mix;
       p_phi_mix = trkPhi_mix;
-      p_ev_mix = trkFromEv_mix;
+      p_ev_mix = trkFromEv_mix_int;
     }
     else if(gen.compare("recogen")==0 || gen.compare("gengen")==0) {
       nip = mult;
@@ -450,6 +451,7 @@ void ztree::ffgammajet(std::string outfname, int centmin, int centmax, float pho
       if(signal) {
         // cout<<ijet<<" "<<jetphi[ijet]<<","<<jeteta[ijet]<<endl;
         hjetpt->Fill(tmpjetpt);
+        hgenjetpt->Fill(tmpjetpt);
         njets_perevent++;
         xjgsignal->Fill(tmpjetpt/phoEtCorrected[0]);
       }
@@ -515,7 +517,7 @@ void ztree::ffgammajet(std::string outfname, int centmin, int centmax, float pho
 //! (2.4) Mix jet loop
     float nmixedjetevents = (nmix+1)/3;
     // nmixedjetevents = 1;
-    for (int ij_mix = 0; ij_mix < nij_mix; ij_mix++) {
+    for (ij_mix = 0; ij_mix < nij_mix; ij_mix++) {
       if( j_ev_mix[ij_mix]%3!= 1) continue;
       if( j_pt_mix[ij_mix]<jetptcut ) continue; //jet pt Cut
       if( fabs(j_eta_mix[ij_mix]) > 1.6) continue; //jeteta_mix Cut

--- a/ffgamma.C
+++ b/ffgamma.C
@@ -427,6 +427,12 @@ void ztree::ffgammajet(std::string outfname, int centmin, int centmax, float pho
       // float tmpjetpt = gjetpt[ijet];
       float tmpjeteta = j_eta[ij];
       float tmpjetphi = j_phi[ij];
+      if( gen.compare("gengen")==0  || gen.compare("genreco")==0) {
+        tmpjetpt *= smeargenpt(isPP,hiBin);
+        tmpjeteta *= smeargeneta(isPP,hiBin);
+        tmpjetphi *= smeargenphi(isPP,hiBin);
+      }
+
 //! apply smearing if pp
       if(isPP)
       {
@@ -447,7 +453,8 @@ void ztree::ffgammajet(std::string outfname, int centmin, int centmax, float pho
       if( tmpjetpt<jetptcut ) continue; //jet pt Cut
       if( fabs(tmpjeteta) > 1.6) continue; //jeteta Cut
       if( acos(cos(tmpjetphi - phoPhi[0])) < 7 * pi / 8 ) continue;
-
+      cout<<jentry<<" "<<tmpjetpt<<" "<<tmpjeteta<<" "<<tmpjetphi<<endl;
+      exit(1);
       if(signal) {
         // cout<<ijet<<" "<<jetphi[ijet]<<","<<jeteta[ijet]<<endl;
         hjetpt->Fill(tmpjetpt);

--- a/ffgamma.C
+++ b/ffgamma.C
@@ -318,23 +318,23 @@ void ztree::ffgammajet(std::string outfname, int centmin, int centmax, float pho
   TH1D * hcent = new TH1D(Form("hcent_%s_%s_%d_%d",tag.data(),s_alpha.data(),abs(centmin),abs(centmax)),Form(";cent;"),200,0,200); // vz weighting check
 
   // iterators
-  int ij, ij_mix, ip, ip_mix;
-  int nij, nij_mix, nip, nip_mix;
-  Int_t * j_ev_mix;
-  Int_t * p_ev_mix;
+  int ij=-1, ij_mix=-1, ip=-1, ip_mix=-1;
+  int nij=-1, nij_mix=-1, nip=-1, nip_mix=-1;
+  Int_t * j_ev_mix=0;
+  Int_t * p_ev_mix=0;
 
-  Float_t * j_pt;
-  Float_t * p_pt;
-  Float_t * p_pt_mix;
-  Float_t * j_pt_mix;
-  Float_t * j_eta;
-  Float_t * j_eta_mix;
-  Float_t * p_eta;
-  Float_t * p_eta_mix;
-  Float_t * j_phi;
-  Float_t * j_phi_mix;
-  Float_t * p_phi;
-  Float_t * p_phi_mix;
+  Float_t * j_pt=0;
+  Float_t * p_pt=0;
+  Float_t * p_pt_mix=0;
+  Float_t * j_pt_mix=0;
+  Float_t * j_eta=0;
+  Float_t * j_eta_mix=0;
+  Float_t * p_eta=0;
+  Float_t * p_eta_mix=0;
+  Float_t * j_phi=0;
+  Float_t * j_phi_mix=0;
+  Float_t * p_phi=0;
+  Float_t * p_phi_mix=0;
 
 //! (2) Loop
   Long64_t nbytes = 0, nb = 0;

--- a/zbalance.h
+++ b/zbalance.h
@@ -46,6 +46,7 @@ class ztree {
    Int_t           dhiBin_mix[96];   //[nmix]
    Float_t         dhiEvtPlanes_mix[96];   //[nmix]
    Int_t           nTrk_mix;
+   Int_t           trkFromEv_mix_int[120000];   //[nTrk_mix]
    Float_t         trkFromEv_mix[120000];   //[nTrk_mix]
    Float_t         trkPt_mix[120000];   //[nTrk_mix]
    Float_t         trkPhi_mix[120000];   //[nTrk_mix]
@@ -451,6 +452,13 @@ ztree::ztree(std::string thisfilename) : fChain(0)
   TFile *f = TFile::Open(thisfilename.data());
   TTree * tree = (TTree*) f->Get("ztree");
   Init(tree);
+}
+
+void float_to_int(Float_t * p1 , Int_t * p2 , int count)
+{
+  for (int i = 0; i < count; i++) {
+    p2[i] = int(p1[i]);
+  }
 }
 
 ztree::~ztree()


### PR DESCRIPTION
instead of duplicating code for different mixtures or reco / gen particles and jets, there is now one loop for jets, and another loop for mix-jets, within are loops for tracks or mixed tracks, and these are set as pointers at the start whether they're reco or gen